### PR TITLE
fix(scroll): divs scroll top after content changes

### DIFF
--- a/src/app/features/command/command-documentation/command-documentation.component.html
+++ b/src/app/features/command/command-documentation/command-documentation.component.html
@@ -1,6 +1,6 @@
 <h3 class="h4 mt-2">Documentation</h3>
 <div class="flex-fill scroll-box-container">
-  <div class="scroll-box">
+  <div class="scroll-box" #scrollBox>
     <div *ngIf="documentation; else noDoc" [innerHTML]="documentation | markdown"></div>
   </div>
 </div>

--- a/src/app/features/command/command-documentation/command-documentation.component.ts
+++ b/src/app/features/command/command-documentation/command-documentation.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, ChangeDetectionStrategy } from '@angular/core';
+import { Component, Input, ChangeDetectionStrategy, ViewChild, ElementRef } from '@angular/core';
 
 @Component({
   selector: 'tr-command-documentation',
@@ -7,5 +7,10 @@ import { Component, Input, ChangeDetectionStrategy } from '@angular/core';
 })
 
 export class CommandDocumentationComponent {
-  @Input() documentation = '';
+  public documentation = '';
+  @ViewChild('scrollBox', {static: true}) scrollBox: ElementRef;
+  @Input('documentation') set resetScroll(document: string){
+    this.documentation = document;
+    this.scrollBox.nativeElement.scrollTop = 0
+  }
 }

--- a/src/app/features/command/command-list/command-list.component.html
+++ b/src/app/features/command/command-list/command-list.component.html
@@ -18,7 +18,7 @@
       <input type="text" class="form-control form-control-sm" placeholder="Search command" #search (input)="true">
     </div>
     <div class="flex-fill scroll-box-container command-list-container">
-      <div class="scroll-box">
+      <div class="scroll-box" #scrollBox>
         <ul>
           <li
             *ngFor="let command of filteredCommands | searchFilter: 'key': search.value | searchFilter: 'group': activeCategory"

--- a/src/app/features/command/command-list/command-list.component.ts
+++ b/src/app/features/command/command-list/command-list.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, Output, ChangeDetectionStrategy } from '@angular/core';
+import { Component, EventEmitter, Input, Output, ChangeDetectionStrategy, ElementRef, ViewChild } from '@angular/core';
 
 import { Command } from '@app/shared/models/command.interface';
 
@@ -15,6 +15,7 @@ export class CommandListComponent {
   activeCommand: Command;
   activeCategory = '';
 
+  @ViewChild('scrollBox', {static: true}) scrollBox: ElementRef;
   @Input('commands') set setCommands(data: Array<Command>) {
     this.filteredCommands = data;
     const array = this.filteredCommands.map(item => item.group);
@@ -55,6 +56,7 @@ export class CommandListComponent {
    * @param category category name
    */
   setActiveCategory(category: string) {
+    this.scrollBox.nativeElement.scrollTop = 0;
     this.activeCategory = category;
   }
 }

--- a/src/app/features/pattern/pattern-content/pattern-content.component.html
+++ b/src/app/features/pattern/pattern-content/pattern-content.component.html
@@ -15,7 +15,7 @@
       </button>
     </div>
 
-    <div class="scroll-box">
+    <div class="scroll-box" #scrollBox>
       <p [innerHTML]="steps[currentStep]  | markdown" *ngIf='steps && steps[currentStep]'></p>
     </div>
 </div>

--- a/src/app/features/pattern/pattern-content/pattern-content.component.ts
+++ b/src/app/features/pattern/pattern-content/pattern-content.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, HostListener, Input, Output, ChangeDetectionStrategy } from '@angular/core';
+import { Component, EventEmitter, HostListener, Input, Output, ChangeDetectionStrategy, ElementRef, ViewChild } from '@angular/core';
 
 import { Pattern } from '@app/shared/models/pattern.interface';
 
@@ -15,7 +15,10 @@ enum Paginator {
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class PatternContentComponent {
+  @ViewChild('scrollBox', {static: false}) scrollBox: ElementRef;
   @Input('patternContent') set newStep(data: Array<string>) {
+    if(this.scrollBox)
+      this.scrollBox.nativeElement.scrollTop = 0;
     this.steps = data;
     this.currentStep = 0;
   }
@@ -40,7 +43,7 @@ export class PatternContentComponent {
       if (targetElement.target.hash === '#run') {
         this.run.emit(command);
       } else {
-        this.help.emit(command);
+        this.help.emit(command);  
       }
     }
 
@@ -49,6 +52,8 @@ export class PatternContentComponent {
    * @param type boolean (TRUE: previous step, FALSE: next step)
    */
   changeStep(type: Paginator) {
+    if(this.scrollBox)
+      this.scrollBox.nativeElement.scrollTop = 0;
     switch (type) {
       case Paginator.FIRST_PAGE:
         this.currentStep = 0;


### PR DESCRIPTION
The scroll bar now goes top after the content changes on each scroll-box div. The previous behaviour was to leave the scroll bar at the previous scroll point