### PR TITLE
fix: remove self reference in header template

### DIFF
--- a/src/app/core/components/header/header.component.html
+++ b/src/app/core/components/header/header.component.html
@@ -8,7 +8,7 @@
       <li class="nav-item">
         <a class="nav-link" target="_blank" href="https://github.com/acadevmy/redis-patterns-console">GitHub</a>
       </li>
-      <li *ngIf="!this.isLogged">
+      <li *ngIf="!isLogged">
         <a class="nav-link btn-auth btn-github" [href]="loginUrl"> Sign in with <b>Github</b></a>
       </li>
     </ul>


### PR DESCRIPTION
## What does this change?

header.component.html

## Why is this change important?

the component renderer fully ignores `this` keyword in the places where it seems valid with some exceptions.
In 99.99% cases, `this` can be omitted for clarity and conciseness.
In 0.01% cases, you MUST omit `this` in order to avoid strange/magic behaviors, for example:

```html
<div #myDiv></div>

<p> {{this.myDiv.innerHTML}} </p>
``` 

What do you expect to happen? and why are you wrong? 🤣
This 2 lines of html work perfectly: "this" although not defined as an attribute of the component, it is still working by referencing `myDiv` correctly.

Are you scared? it doesn't make sense? I agree with you. So it is always better to omit "this" in template. 😉

## How can I test it?

nothing to test
