### PR TITLE
Split cache interceptor

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -23,7 +23,7 @@ export class AppComponent {
   activePattern: Pattern;
   newCommandForInput: string;
   resetCommand$: Observable<number> = this.redisConnectService.execCommandTime$;
-  isAuth$: Observable<boolean> = this.githubDataService.isAuth;
+  isAuth$: Observable<boolean> = this.githubDataService.isAuth$;
 
   constructor(
     private githubDataService: GithubDataService,

--- a/src/app/core/core.module.ts
+++ b/src/app/core/core.module.ts
@@ -4,6 +4,7 @@ import { CommonModule } from '@angular/common';
 
 import { ConfigService } from './services/config.service';
 import { CacheInterceptor } from './interceptors/cache-interceptor';
+import { AuthInterceptor } from './interceptors/auth.interceptor';
 import { HeaderComponent } from '@app/core/components/header/header.component';
 
 @NgModule({
@@ -29,6 +30,11 @@ import { HeaderComponent } from '@app/core/components/header/header.component';
     {
       provide: HTTP_INTERCEPTORS,
       useClass: CacheInterceptor,
+      multi: true
+    },
+    {
+      provide: HTTP_INTERCEPTORS,
+      useClass: AuthInterceptor,
       multi: true
     }
   ],

--- a/src/app/core/interceptors/auth.interceptor.ts
+++ b/src/app/core/interceptors/auth.interceptor.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@angular/core';
+import {
+  HttpEvent,
+  HttpHandler,
+  HttpInterceptor,
+  HttpRequest
+} from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { GithubDataService } from '@app/core/services/github-data.service';
+​
+@Injectable({
+  providedIn: 'root'
+})
+export class AuthInterceptor implements HttpInterceptor {
+  public constructor(private githubDataService: GithubDataService) { }
+​
+  public intercept(request: HttpRequest<any>, next: HttpHandler ): Observable<HttpEvent<any>> {
+    if (this.isAuthenticated()) {
+      request = this.createAuthenticatedRequest(request);
+    }
+​
+    return next.handle(request);
+  }
+
+  private createAuthenticatedRequest(request: HttpRequest<any>) {
+    return request.clone({ setHeaders: { Authorization: `token ${this.githubDataService.accessToken}` } });
+  }
+
+  private isAuthenticated(): boolean {
+    return this.githubDataService.isAuth;
+  }
+}

--- a/src/app/core/interceptors/cache-interceptor.ts
+++ b/src/app/core/interceptors/cache-interceptor.ts
@@ -11,20 +11,15 @@ import { tap } from 'rxjs/operators';
 ​
 import { environment } from '@app/../environments/environment';
 import { CachingService } from '@app/core/services/caching.service';
-import { GithubDataService } from '@app/core/services/github-data.service';
 ​
 @Injectable({
   providedIn: 'root'
 })
 export class CacheInterceptor implements HttpInterceptor {
 ​
-  constructor(private cachingService: CachingService, private githubDataService: GithubDataService) { }
+  constructor(private cachingService: CachingService) { }
 ​
-  intercept(request: HttpRequest<any>, next: HttpHandler ): Observable<HttpEvent<any>> {
-    if (this.githubDataService.accessToken && this.githubDataService.accessToken.length) {
-      request = request.clone({ setHeaders: { Authorization: `token ${this.githubDataService.accessToken}` } });
-    }
-​
+  intercept(request: HttpRequest<any>, next: HttpHandler ): Observable<HttpEvent<any>> {​
     if (!request.headers.has(environment.cacheableHeaderKey))  {
       return next.handle(request);
     }

--- a/src/app/core/services/github-data.service.ts
+++ b/src/app/core/services/github-data.service.ts
@@ -101,16 +101,20 @@ export class GithubDataService {
         const isToken = (res.data.access_token) ? true : false;
         this.authorized.next(isToken);
         this.accessToken = res.data && res.data.access_token;
-        return this.isAuth;
+        return this.isAuth$;
       }),
       catchError(() => {
         this.authorized.next(false);
-        return this.isAuth;
+        return this.isAuth$;
       })
     );
   }
 
-  get isAuth() {
+  get isAuth$() {
     return this.authorized.asObservable();
+  }
+
+  get isAuth(): boolean {
+    return this.authorized.value;
   }
 }


### PR DESCRIPTION
## What does this change?

extract auth interceptor from cache interceptor

## Why is this change important?

dividing responsabilities into two interceptors respects DRY, improving readability and testability of features.

## How can I test it?

cache: when user make a request, it may be executed first time only.

auth: when user is authenticated with GitHub, check auth token in Authorization header.
